### PR TITLE
fix: Replace `Box<dyn Error>` with static version

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -1,8 +1,5 @@
 use thiserror::Error;
 
-#[cfg(feature = "tokio-modbus")]
-use crate::tokio_modbus::TokioModbusError;
-
 /// This error is returned if a communication fails because of a timeout
 /// or underlying modbus error.
 #[derive(Error, Debug)]
@@ -10,18 +7,4 @@ pub enum CommunicationError {
     /// The operation timed out
     #[error("Timeout")]
     Timeout,
-    /// Implementation specific modbus error
-    #[cfg(feature = "tokio-modbus")]
-    #[error("Modbus")]
-    Modbus(#[from] TokioModbusError),
-}
-
-#[cfg(feature = "tokio-modbus")]
-impl CommunicationError {
-    pub(crate) fn from_modbus_error(e: tokio_modbus::Error) -> Self {
-        Self::Modbus(TokioModbusError::Error(e))
-    }
-    pub(crate) fn from_modbus_exception(e: tokio_modbus::Exception) -> Self {
-        Self::Modbus(TokioModbusError::Exception(e))
-    }
 }


### PR DESCRIPTION
Since 0.5 I'm getting `(dyn StdError + 'static) cannot be shared between threads safely` errors. This should make it easier to use `sunspec` in multi-threaded environments again.