### PR TITLE
fix: Still couldn't share error between threads

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -11,12 +11,12 @@ pub enum CommunicationError {
     Timeout,
     /// Implementation specific modbus error
     #[error("Modbus")]
-    Modbus(Box<dyn Error + Send>),
+    Modbus(Box<dyn Error + Send + Sync>),
 }
 
 impl CommunicationError {
     /// Create communication error from implementation specific modbus error
-    pub fn from_modbus(error: impl Error + Send + 'static) -> Self {
+    pub fn from_modbus(error: impl Error + Send + Sync + 'static) -> Self {
         Self::Modbus(Box::new(error))
     }
 }


### PR DESCRIPTION
After 0.6.0 I was still receiving compile errors for the dyn Error, as seen below. This PR fixes the issue for me.

```
(dyn std::error::Error + Send + 'static)` cannot be shared between threads safely
the trait `Sync` is not implemented for `(dyn std::error::Error + Send + 'static)`, which is required by `std::result::Result<Box<dyn std::fmt::Debug>, anyhow::Error>: FromResidual<std::result::Result<Infallible, sunspec::model::ReadModelError>>`
the trait `FromResidual<std::result::Result<Infallible, E>>` is implemented for `std::result::Result<T, F>`
required for `std::ptr::Unique<(dyn std::error::Error + Send + 'static)>` to implement `Sync`
required for `anyhow::Error` to implement `From<sunspec::model::ReadModelError>`
required for `std::result::Result<Box<dyn std::fmt::Debug>, anyhow::Error>` to implement `FromResidual<std::result::Result<Infallible, sunspec::model::ReadModelError>>
```

Other relevant discussion: #7