### PR TITLE
Exaple of sunspec library with Security Modbus.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,4 +29,4 @@ tokio-modbus = { version = "0.16", optional = true }
 serde_json = "1.0.114"
 
 [workspace]
-members = ["sunspec-gen", "examples/readme", "examples/model103"]
+members = ["sunspec-gen", "examples/readme", "examples/model103", "examples/model701_tls"]


### PR DESCRIPTION
This is an example of how to use sunspec library with Modbus Security.

A server example (virtual inverter example) can be found in: [https://github.com/gustavowd/sunspec-models/tree/main/examples/server_example](https://github.com/gustavowd/sunspec-models/tree/main/examples/server_example)

Best regards,
Gustavo